### PR TITLE
Optimized expand\collapse tasks time

### DIFF
--- a/My Project/ExTableLayoutPanel.vb
+++ b/My Project/ExTableLayoutPanel.vb
@@ -1,22 +1,62 @@
-﻿Public Class ExTableLayoutPanel
-    ' https://www.vbforums.com/showthread.php?600989-Slow-resizing-of-a-TableLayoutPanel
+﻿Imports System.Runtime.InteropServices
+
+Public Class ExTableLayoutPanel
+    ''''' https://www.vbforums.com/showthread.php?600989-Slow-resizing-of-a-TableLayoutPanel
+
+    ' https://stackoverflow.com/questions/8900099/tablelayoutpanel-responds-very-slowly-to-events
 
     Inherits TableLayoutPanel
 
     Public Property Task As Task
 
     Public Sub New()
-        Me.SetStyle(ControlStyles.AllPaintingInWmPaint, True)
-        Me.SetStyle(ControlStyles.OptimizedDoubleBuffer, True)
+        'Me.SetStyle(ControlStyles.AllPaintingInWmPaint, True)
+        'Me.SetStyle(ControlStyles.OptimizedDoubleBuffer, True)
 
         Me.Task = Nothing
     End Sub
 
     Public Sub New(Task As Task)
-        Me.SetStyle(ControlStyles.AllPaintingInWmPaint, True)
-        Me.SetStyle(ControlStyles.OptimizedDoubleBuffer, True)
+        'Me.SetStyle(ControlStyles.AllPaintingInWmPaint, True)
+        'Me.SetStyle(ControlStyles.OptimizedDoubleBuffer, True)
 
         Me.Task = Task
     End Sub
 
+
+
+    Protected Overrides Sub OnCreateControl()
+        MyBase.OnCreateControl()
+        Me.SetStyle(ControlStyles.OptimizedDoubleBuffer Or ControlStyles.CacheText, True)
+    End Sub
+
+    Protected Overrides ReadOnly Property CreateParams As CreateParams
+        Get
+            Dim cp As CreateParams = MyBase.CreateParams
+            cp.ExStyle = cp.ExStyle Or NativeMethods.WS_EX_COMPOSITED
+            Return cp
+        End Get
+    End Property
+
+    Public Sub BeginUpdate()
+        NativeMethods.SendMessage(Me.Handle, NativeMethods.WM_SETREDRAW, IntPtr.Zero, IntPtr.Zero)
+    End Sub
+
+    Public Sub EndUpdate()
+        NativeMethods.SendMessage(Me.Handle, NativeMethods.WM_SETREDRAW, New IntPtr(1), IntPtr.Zero)
+        Parent.Invalidate(True)
+    End Sub
+
+
+
 End Class
+
+Module NativeMethods
+    Public WM_SETREDRAW As Integer = &HB
+    Public WS_EX_COMPOSITED As Integer = &H2000000
+    <DllImport("user32.dll", CharSet:=CharSet.Auto)>
+    Function SendMessage(ByVal hWnd As IntPtr, ByVal Msg As Integer, ByVal wParam As IntPtr, ByVal lParam As IntPtr) As IntPtr
+
+    End Function
+
+End Module

--- a/My Project/InterfaceUtilities.vb
+++ b/My Project/InterfaceUtilities.vb
@@ -404,7 +404,9 @@ Public Class InterfaceUtilities
         CheckBox.Appearance = Appearance.Button
         CheckBox.FlatStyle = FlatStyle.Flat
         CheckBox.FlatAppearance.BorderSize = 0
-        CheckBox.FlatAppearance.CheckedBackColor = SystemColors.Control
+        CheckBox.FlatAppearance.CheckedBackColor = Color.Transparent
+        CheckBox.FlatAppearance.MouseOverBackColor = Color.Transparent 'SystemColors.Control
+        CheckBox.FlatAppearance.MouseDownBackColor = Color.Transparent
 
         CheckBox.Image = Image
 

--- a/My Project/Task_EventHandler.vb
+++ b/My Project/Task_EventHandler.vb
@@ -55,6 +55,10 @@ Public Class Task_EventHandler
                     Next
 
                     'Form1.SuspendLayout()
+                    'Form1.TabPageTasks.SuspendLayout()
+                    'Form1.TabPageTasks.Hide() '####### It works good for collapsing all controls; doensn't speed up for expanding; perhaps
+
+                    Form1.Cursor = Cursors.WaitCursor
 
                     For Each Task In Form1.TaskList
                         If Task.HasOptions Then
@@ -79,6 +83,10 @@ Public Class Task_EventHandler
                         End If
                     Next
 
+                    Form1.Cursor = Cursors.Default
+
+                    'Form1.TabPageTasks.ResumeLayout()
+                    'Form1.TabPageTasks.Show()
                     'Form1.ResumeLayout()
 
                 Case Task.BaseControlNames.SelectTask.ToString


### PR DESCRIPTION
With this changes the time to expand\collapse is reasonable and the interface doesn't look mad while doing it
Also added a wait cursor during the expand\collapse

I still think that creating a custom control that handles the single task options would be the way to go