### PR TITLE
Add file extension document type check to part and sheet metal

### DIFF
--- a/My Project/LabelToAction.vb
+++ b/My Project/LabelToAction.vb
@@ -504,6 +504,13 @@ Public Class LabelToAction
                      "PartNumberDoesNotMatchFilename",
                      HelpString,
                      RequiresPartNumberFields:=True)
+        
+        Dim FileExtTypeMismatch As New L2A
+        HelpString = "Checks for mismatch between document type and file extension. "
+        PopulateList(FileExtTypeMismatch,
+                     "File extension type mismatch",
+                     "FileExtTypeMismatch",
+                     HelpString)
 
         Dim MissingDrawing As New L2A
         HelpString = "Same as the Assembly command of the same name."
@@ -688,6 +695,13 @@ Public Class LabelToAction
                      "PartNumberDoesNotMatchFilename",
                      HelpString,
                      RequiresPartNumberFields:=True)
+        
+        Dim FileExtTypeMismatch As New L2A
+        HelpString = "Checks for mismatch between document type and file extension. "
+        PopulateList(FileExtTypeMismatch,
+                     "File extension type mismatch",
+                     "FileExtTypeMismatch",
+                     HelpString)
 
         Dim MissingDrawing As New L2A
         HelpString = "Same as the Assembly command of the same name."

--- a/My Project/LaunchTask.vb
+++ b/My Project/LaunchTask.vb
@@ -134,6 +134,8 @@ Public Class LaunchTask
                     ErrorMessage = task.Proxy.MaterialNotInMaterialTable(SEDoc, Configuration, SEApp)
                 Case "PartNumberDoesNotMatchFilename"
                     ErrorMessage = task.Proxy.PartNumberDoesNotMatchFilename(SEDoc, Configuration, SEApp)
+                Case "FileExtTypeMismatch"
+                    ErrorMessage = task.Proxy.FileExtTypeMismatch(SEDoc, Configuration, SEApp)
                 Case "UpdateInsertPartCopies"
                     ErrorMessage = task.Proxy.UpdateInsertPartCopies(SEDoc, Configuration, SEApp)
                 Case "UpdateMaterialFromMaterialTable"
@@ -201,6 +203,8 @@ Public Class LaunchTask
                     ErrorMessage = task.Proxy.UnderconstrainedProfiles(SEDoc, Configuration, SEApp)
                 Case "FlatPatternMissingOrOutOfDate"
                     ErrorMessage = task.Proxy.FlatPatternMissingOrOutOfDate(SEDoc, Configuration, SEApp)
+                Case "FileExtTypeMismatch"
+                    ErrorMessage = task.Proxy.FileExtTypeMismatch(SEDoc, Configuration, SEApp)
                 Case "InsertPartCopiesOutOfDate"
                     ErrorMessage = task.Proxy.InsertPartCopiesOutOfDate(SEDoc, Configuration, SEApp)
                 Case "BrokenLinks"

--- a/My Project/PartTasks.vb
+++ b/My Project/PartTasks.vb
@@ -1,5 +1,6 @@
 ﻿Option Strict On
 
+Imports System.IO
 Imports SolidEdgeCommunity
 
 Public Class PartTasks
@@ -566,7 +567,47 @@ Public Class PartTasks
         Return ErrorMessage
     End Function
 
+    Public Function FileExtTypeMismatch(
+                                        ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
+                                        ByVal Configuration As Dictionary(Of String, String),
+                                        ByVal SEApp As SolidEdgeFramework.Application
+                                        ) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        ErrorMessage = InvokeSTAThread(
+            Of SolidEdgeFramework.SolidEdgeDocument,
+            Dictionary(Of String, String),
+            SolidEdgeFramework.Application,
+            Dictionary(Of Integer, List(Of String)))(
+                AddressOf FileExtTypeMismatchInternal,
+                CType(SEDoc, SolidEdgeFramework.SolidEdgeDocument),
+                Configuration,
+                SEApp)
+
+        Return ErrorMessage
+
+    End Function
+
+    Private Function FileExtTypeMismatchInternal(
+                                                 ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
+                                                 ByVal Configuration As Dictionary(Of String, String),
+                                                 ByVal SEApp As SolidEdgeFramework.Application
+                                                 ) As Dictionary(Of Integer, List(Of String))
+
+        Dim ErrorMessageList As New List(Of String)
+        Dim ExitStatus As Integer = 0
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Dim docType = SEDoc.Type
+        if docType <> SolidEdgeFramework.DocumentTypeConstants.igPartDocument
+            ExitStatus = 1
+            ErrorMessageList.Add("Part type does not match file extension: " + docType.ToString())
+        End If
+
+        ErrorMessage(ExitStatus) = ErrorMessageList
+        Return ErrorMessage
+    End Function
 
     Public Function UpdateInsertPartCopies(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,

--- a/My Project/SheetmetalTasks.vb
+++ b/My Project/SheetmetalTasks.vb
@@ -1,5 +1,6 @@
 ﻿Option Strict On
 
+Imports System.IO
 Imports SolidEdgeCommunity
 Imports SolidEdgePart
 
@@ -459,8 +460,48 @@ Public Class SheetmetalTasks
         ErrorMessage(ExitStatus) = ErrorMessageList
         Return ErrorMessage
     End Function
+    
+    Public Function FileExtTypeMismatch(
+        ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
+        ByVal Configuration As Dictionary(Of String, String),
+        ByVal SEApp As SolidEdgeFramework.Application
+        ) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
 
+        ErrorMessage = InvokeSTAThread(
+            Of SolidEdgeFramework.SolidEdgeDocument,
+            Dictionary(Of String, String),
+            SolidEdgeFramework.Application,
+            Dictionary(Of Integer, List(Of String)))(
+                AddressOf FileExtTypeMismatchInternal,
+                CType(SEDoc, SolidEdgeFramework.SolidEdgeDocument),
+                Configuration,
+                SEApp)
+
+        Return ErrorMessage
+
+    End Function
+
+    Private Function FileExtTypeMismatchInternal(
+        ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
+        ByVal Configuration As Dictionary(Of String, String),
+        ByVal SEApp As SolidEdgeFramework.Application
+        ) As Dictionary(Of Integer, List(Of String))
+
+        Dim ErrorMessageList As New List(Of String)
+        Dim ExitStatus As Integer = 0
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Dim docType = SEDoc.Type
+        if docType <> SolidEdgeFramework.DocumentTypeConstants.igSheetMetalDocument
+            ExitStatus = 1
+            ErrorMessageList.Add("Part type does not match file extension: " + docType.ToString())
+        End If
+
+        ErrorMessage(ExitStatus) = ErrorMessageList
+        Return ErrorMessage
+    End Function
 
     Public Function MaterialNotInMaterialTable(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,


### PR DESCRIPTION
I based this on the latest release as there appears to be some major unfinished structural changes going on right now. Please edit accordingly or advise how I can update it to the new project layout.

This PR adds check options to the part and sheet metal tabs to check the file extension against the SE document type. This was added because historically some people have advised on the official SE message board that .PAR and .PSM file formats are identical, and that you can change the file extensions with impunity. This is not the case, as the underlying document type remains the same as the originally created file type even through environment changes and file saves. I now have a library of parts which were created as .PAR files but at some point renamed to .PSM and treated as sheet metal parts. This becomes an issue when you try to cast the document to a sheet metal part via the API. It will fail.

You can demonstrate this issue by creating a new .PAR file, renaming it to .PSM, then running it through any of the sheet metal checks in Housekeeper which cast to a SheetMetalDocument type. It will fail with a cast exception.

Perhaps since this impacts other checks in the sheet metal and part tabs, it should be implemented in a way in which the check is done before any other checks.