### PR TITLE
Regenerate missing flat model

### DIFF
--- a/Housekeeper.vbproj
+++ b/Housekeeper.vbproj
@@ -247,6 +247,7 @@
     <Compile Include="My Project\TaskHideConstructions.vb" />
     <Compile Include="My Project\TaskOpenSave.vb" />
     <Compile Include="My Project\TaskPrint.vb" />
+    <Compile Include="My Project\TaskRegenerateFlatModel.vb" />
     <Compile Include="My Project\TaskRemoveFaceStyleOverrides.vb" />
     <Compile Include="My Project\TaskRunExternalProgram.vb" />
     <Compile Include="My Project\TaskSaveDrawingAs.vb" />

--- a/My Project/PreferencesUtilities.vb
+++ b/My Project/PreferencesUtilities.vb
@@ -134,6 +134,7 @@ Public Class PreferencesUtilities
         TaskList.Add(New TaskUpdateModelSizeInVariableTable)
         TaskList.Add(New TaskUpdateDesignForCost)
         TaskList.Add(New TaskUpdateDrawingViews)
+        TaskList.Add(New TaskRegenerateFlatModel)
 
         ' Edit
         TaskList.Add(New TaskEditProperties)

--- a/My Project/TaskRegenerateFlatModel.vb
+++ b/My Project/TaskRegenerateFlatModel.vb
@@ -65,17 +65,24 @@ Public Class TaskRegenerateFlatModel
 
         Dim TC As New Task_Common
         
-        SEDoc.Activate
-        SEApp.DoIdle()
-        SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalToolsSelectTool)
-        SEApp.DoIdle()
-        SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalModelFlatPattern)
-        SEApp.DoIdle()
+        If Not SEApp.Visible Then
+            ExitStatus = 1
+            ErrorMessageList.Add("Cannot regenerate flat model in background mode")
+        Else
+            SEDoc.Activate
+            SEApp.DoIdle()
+            SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalToolsSelectTool)
+            SEApp.DoIdle()
+            SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalModelFlatPattern)
+            SEApp.DoIdle()
+        End If
         
         If SEDoc.ReadOnly Then
             ExitStatus = 1
             ErrorMessageList.Add("Cannot save document marked 'Read Only'")
-        Else
+        End If
+        
+        If ExitStatus = 0 Then
             SEDoc.Save()
             SEApp.DoIdle()
         End If
@@ -122,7 +129,6 @@ Public Class TaskRegenerateFlatModel
                 ExitStatus = 1
                 ErrorMessageList.Add(String.Format("{0}Select at least one type of file to process", Indent))
             End If
-
         End If
 
         If ExitStatus > 0 Then  ' Start conditions not met.

--- a/My Project/TaskRegenerateFlatModel.vb
+++ b/My Project/TaskRegenerateFlatModel.vb
@@ -64,17 +64,26 @@ Public Class TaskRegenerateFlatModel
         Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
 
         Dim TC As New Task_Common
+        Dim DocType = TC.GetDocType(SEDoc)
+        
+        ' Get FlatpatternModels collection to check if flat patterns exist
+        Dim FlatpatternModels As SolidEdgePart.FlatPatternModels
+        Select Case DocType
+            Case = "par"
+                Dim tmpSEDoc = CType(SEDoc, SolidEdgePart.PartDocument)
+                FlatpatternModels = tmpSEDoc.FlatPatternModels
+
+            Case = "psm"
+                Dim tmpSEDoc = CType(SEDoc, SolidEdgePart.SheetMetalDocument)
+                FlatpatternModels = tmpSEDoc.FlatPatternModels
+
+            Case Else
+                MsgBox(String.Format("{0} DocType '{0}' not recognized", Me.Name, DocType))
+        End Select
         
         If Not SEApp.Visible Then
             ExitStatus = 1
             ErrorMessageList.Add("Cannot regenerate flat model in background mode")
-        Else
-            SEDoc.Activate
-            SEApp.DoIdle()
-            SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalToolsSelectTool)
-            SEApp.DoIdle()
-            SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalModelFlatPattern)
-            SEApp.DoIdle()
         End If
         
         If SEDoc.ReadOnly Then
@@ -82,7 +91,14 @@ Public Class TaskRegenerateFlatModel
             ErrorMessageList.Add("Cannot save document marked 'Read Only'")
         End If
         
-        If ExitStatus = 0 Then
+        ' Active flat environment to regenerate flat model then save part if no errors
+        If ExitStatus = 0 And FlatpatternModels.Count > 0 Then
+            SEDoc.Activate
+            SEApp.DoIdle()
+            SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalToolsSelectTool)
+            SEApp.DoIdle()
+            SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalModelFlatPattern)
+            SEApp.DoIdle()
             SEDoc.Save()
             SEApp.DoIdle()
         End If

--- a/My Project/TaskRegenerateFlatModel.vb
+++ b/My Project/TaskRegenerateFlatModel.vb
@@ -1,0 +1,147 @@
+﻿Option Strict On
+
+Imports SolidEdgeCommunity.Extensions
+Imports SolidEdgeConstants
+
+Public Class TaskRegenerateFlatModel
+
+    Inherits Task
+
+    Public Sub New()
+        Me.Name = Me.ToString.Replace("Housekeeper.", "")
+        Me.Description = GenerateLabelText()
+        Me.HelpText = GetHelpText()
+        Me.RequiresSave = True
+        Me.AppliesToAssembly = False
+        Me.AppliesToPart = True
+        Me.AppliesToSheetmetal = True
+        Me.AppliesToDraft = False
+        Me.HasOptions = False
+        Me.HelpURL = GenerateHelpURL(Description)
+        Me.Image = My.Resources.TaskCheckFlatPattern
+        Me.Category = "Update"
+
+        SetColorFromCategory(Me)
+        ' Options
+    End Sub
+
+    Public Sub New(Task As TaskRegenerateFlatModel)
+
+        'Options
+
+    End Sub
+
+    Public Overrides Function Process(
+        ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
+        ByVal Configuration As Dictionary(Of String, String),
+        ByVal SEApp As SolidEdgeFramework.Application
+        ) As Dictionary(Of Integer, List(Of String))
+
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        ErrorMessage = InvokeSTAThread(
+                               Of SolidEdgeFramework.SolidEdgeDocument,
+                               Dictionary(Of String, String),
+                               SolidEdgeFramework.Application,
+                               Dictionary(Of Integer, List(Of String)))(
+                                   AddressOf ProcessInternal,
+                                   SEDoc,
+                                   Configuration,
+                                   SEApp)
+
+        Return ErrorMessage
+
+    End Function
+
+    Private Function ProcessInternal(
+        ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
+        ByVal Configuration As Dictionary(Of String, String),
+        ByVal SEApp As SolidEdgeFramework.Application
+        ) As Dictionary(Of Integer, List(Of String))
+
+        Dim ErrorMessageList As New List(Of String)
+        Dim ExitStatus As Integer = 0
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Dim TC As New Task_Common
+        
+        SEDoc.Activate
+        SEApp.DoIdle()
+        SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalToolsSelectTool)
+        SEApp.DoIdle()
+        SEApp.StartCommand(SheetMetalCommandConstants.SheetMetalModelFlatPattern)
+        SEApp.DoIdle()
+        
+        If SEDoc.ReadOnly Then
+            ExitStatus = 1
+            ErrorMessageList.Add("Cannot save document marked 'Read Only'")
+        Else
+            SEDoc.Save()
+            SEApp.DoIdle()
+        End If
+
+        ErrorMessage(ExitStatus) = ErrorMessageList
+        Return ErrorMessage
+
+    End Function
+
+    Public Overrides Function GetTLPTask(TLPParent As ExTableLayoutPanel) As ExTableLayoutPanel
+        ControlsDict = New Dictionary(Of String, Control)
+
+        Dim IU As New InterfaceUtilities
+
+        Me.TLPTask = IU.BuildTLPTask(Me, TLPParent)
+
+        For Each Control As Control In Me.TLPTask.Controls
+            If ControlsDict.Keys.Contains(Control.Name) Then
+                MsgBox(String.Format("ControlsDict already has Key '{0}'", Control.Name))
+            End If
+            ControlsDict(Control.Name) = Control
+        Next
+
+        Return Me.TLPTask
+    End Function
+
+    Public Overrides Function CheckStartConditions(
+        PriorErrorMessage As Dictionary(Of Integer, List(Of String))
+        ) As Dictionary(Of Integer, List(Of String))
+
+        Dim PriorExitStatus As Integer = PriorErrorMessage.Keys(0)
+
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+        Dim ExitStatus As Integer = 0
+        Dim ErrorMessageList = PriorErrorMessage(PriorExitStatus)
+        Dim Indent = "    "
+
+        If Me.IsSelectedTask Then
+            ' Check start conditions.
+            If Not (Me.IsSelectedAssembly Or Me.IsSelectedPart Or Me.IsSelectedSheetmetal Or Me.IsSelectedDraft) Then
+                If Not ErrorMessageList.Contains(Me.Description) Then
+                    ErrorMessageList.Add(Me.Description)
+                End If
+                ExitStatus = 1
+                ErrorMessageList.Add(String.Format("{0}Select at least one type of file to process", Indent))
+            End If
+
+        End If
+
+        If ExitStatus > 0 Then  ' Start conditions not met.
+            ErrorMessage(ExitStatus) = ErrorMessageList
+            Return ErrorMessage
+        Else
+            Return PriorErrorMessage
+        End If
+
+    End Function
+
+
+    Private Function GetHelpText() As String
+        Dim HelpString As String
+        HelpString = "Regenerates missing flat models by activating flat environment. "
+        HelpString += "Requires running in foreground. "
+
+        Return HelpString
+    End Function
+
+
+End Class


### PR DESCRIPTION
In very rare conditions that seem to coincide with CopyConstruction features, a part can be "missing" the 3D flat model. This is completely undetectable via the GUI as this model is automatically regenerated when entering the Flatten environment.

This issue impacts interop software that interacts with the flat models via the API in the background. Consider the following (incomplete C#) code:

```C#
partDoc = (SE.SolidEdgeDocument)application.Documents.Open(path);
sheetMetalDoc = (SEPar.SheetMetalDocument)partDoc;
var flatModels = sheetMetalDoc.FlatPatternModels;
var flatModel = flatModels.Item(1);
flatModel.MakeActive();
sheetMetalDoc.SaveCopyAs($"{sheetMetalDoc.Name}.stp");
```

Under normal circumstances, if you have the "Use Current Configuration" option set in your STEP Part Simplification Export Options, this code will output a STEP file of the flat model.

![image](https://github.com/rmcanany/SolidEdgeHousekeeper/assets/47229638/881832ca-9beb-48ec-a99e-d8ed1011a23c)

If you run this code on a part with the "missing" flat model, it will produce no errors but will output an empty STEP file with no geometry. This causes issues with CAM and other software that exports flat models from Solid Edge parts.

This script will open a part in the foreground, switch to the flatten environment, then save the part. This regenerates the flat model and the newly saved part will no longer break third party software.

I added this under the Update category as it seemed most appropriate. I can resubmit under Edit if that makes more sense.

Attached is a ZIP containing demonstration parts for posterity. The -BEFORE PSM is in a broken state. The -BEFORE STP file is the output of the broken PSM when saving via the API. I tested this part using the code in this PR then ran it through an API-based STEP export again and the -AFTER STP file was correctly generated. I no longer have a large assembly to test it on as I've corrected all of my known bad assemblies with my own original script already.

Ideally, and in the original code, this would check for the bad STEP files before performing the regen and save. That adds additional dependencies via a STEP file parsing library so it is not included in this PR. Switching environments and saving should be non-destructive as it's not forcing any changes, just allowing Solid Edge to update the part state as it would through normal operation of the GUI.

I added read-only, background, and and FlatpatternModel count checks. Part processing logic is in an If statement that checks exist status before starting, as it's a resource-intensive foreground operation that requires UI updates. No sense processing a part if it's just going to throw an error code afterward. Let me know if there's anything I can do to clean this up to keep it more within your project style.

I should probably include a PR for documentation updates as well. Since this won't make it to release soon, I can look up the structure for that another day.

[MissingFlatModelTest.zip](https://github.com/rmcanany/SolidEdgeHousekeeper/files/15311320/MissingFlatModelTest.zip)
