### PR TITLE
Solid Edge required implemented

### DIFF
--- a/My Project/Task.vb
+++ b/My Project/Task.vb
@@ -49,6 +49,7 @@ Public MustInherit Class Task
     Public Property DraftTemplate As String
     Public Property MaterialTable As String
     Public Property Category As String
+    Public Property SolidEdgeRequired As Boolean = True
 
 
 
@@ -70,6 +71,8 @@ Public MustInherit Class Task
         Configuration As Dictionary(Of String, String),
         SEApp As SolidEdgeFramework.Application
         ) As Dictionary(Of Integer, List(Of String))
+
+    Public MustOverride Function Process(FileName As String) As Dictionary(Of Integer, List(Of String))
 
     Public MustOverride Function GetTLPTask(
         TLPParent As ExTableLayoutPanel

--- a/My Project/TaskActivateAndUpdateAll.vb
+++ b/My Project/TaskActivateAndUpdateAll.vb
@@ -47,6 +47,13 @@ Public Class TaskActivateAndUpdateAll
 
     End Function
 
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
+
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskBreakPartCopyLinks.vb
+++ b/My Project/TaskBreakPartCopyLinks.vb
@@ -62,6 +62,13 @@ Public Class TaskBreakPartCopyLinks
 
     End Function
 
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
+
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckDrawingPartsList.vb
+++ b/My Project/TaskCheckDrawingPartsList.vb
@@ -50,7 +50,13 @@ Public Class TaskCheckDrawingPartsList
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckDrawings.vb
+++ b/My Project/TaskCheckDrawings.vb
@@ -70,7 +70,13 @@ Public Class TaskCheckDrawings
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckFlatPattern.vb
+++ b/My Project/TaskCheckFlatPattern.vb
@@ -50,7 +50,13 @@ Public Class TaskCheckFlatPattern
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckInterference.vb
+++ b/My Project/TaskCheckInterference.vb
@@ -62,7 +62,13 @@ Public Class TaskCheckInterference
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckLinks.vb
+++ b/My Project/TaskCheckLinks.vb
@@ -70,7 +70,13 @@ Public Class TaskCheckLinks
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckMaterialNotInMaterialTable.vb
+++ b/My Project/TaskCheckMaterialNotInMaterialTable.vb
@@ -60,7 +60,13 @@ Public Class TaskCheckMaterialNotInMaterialTable
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckMissingDrawing.vb
+++ b/My Project/TaskCheckMissingDrawing.vb
@@ -51,7 +51,13 @@ Public Class TaskCheckMissingDrawing
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckPartCopies.vb
+++ b/My Project/TaskCheckPartCopies.vb
@@ -50,7 +50,13 @@ Public Class TaskCheckPartCopies
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckPartNumberDoesNotMatchFilename.vb
+++ b/My Project/TaskCheckPartNumberDoesNotMatchFilename.vb
@@ -66,7 +66,13 @@ Public Class TaskCheckPartNumberDoesNotMatchFilename
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskCheckRelationships.Aux.vb
+++ b/My Project/TaskCheckRelationships.Aux.vb
@@ -6,5 +6,12 @@ Partial Class TaskCheckRelationships
 		Return a.Plane
 	End Function
 
+	Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
+
+		Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+		Return ErrorMessage
+
+	End Function
 
 End Class

--- a/My Project/TaskEditInteractively.vb
+++ b/My Project/TaskEditInteractively.vb
@@ -50,7 +50,13 @@ Public Class TaskEditInteractively
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskEditVariables.vb
+++ b/My Project/TaskEditVariables.vb
@@ -64,7 +64,13 @@ Public Class TaskEditVariables
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskFitView.vb
+++ b/My Project/TaskFitView.vb
@@ -71,7 +71,13 @@ Public Class TaskFitView
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskHideConstructions.vb
+++ b/My Project/TaskHideConstructions.vb
@@ -55,7 +55,13 @@ Public Class TaskHideConstructions
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskOpenSave.vb
+++ b/My Project/TaskOpenSave.vb
@@ -51,7 +51,13 @@ Public Class TaskOpenSave
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskPrint.vb
+++ b/My Project/TaskPrint.vb
@@ -100,7 +100,13 @@ Public Class TaskPrint
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskRegenerateFlatModel.vb
+++ b/My Project/TaskRegenerateFlatModel.vb
@@ -52,7 +52,13 @@ Public Class TaskRegenerateFlatModel
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskRemoveFaceStyleOverrides.vb
+++ b/My Project/TaskRemoveFaceStyleOverrides.vb
@@ -51,7 +51,13 @@ Public Class TaskRemoveFaceStyleOverrides
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskRunExternalProgram.vb
+++ b/My Project/TaskRunExternalProgram.vb
@@ -66,7 +66,13 @@ Public Class TaskRunExternalProgram
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskSaveDrawingAs.vb
+++ b/My Project/TaskSaveDrawingAs.vb
@@ -110,7 +110,13 @@ Public Class TaskSaveDrawingAs
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskSaveModelAs.vb
+++ b/My Project/TaskSaveModelAs.vb
@@ -107,7 +107,13 @@ Public Class TaskSaveModelAs
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdateDesignForCost.vb
+++ b/My Project/TaskUpdateDesignForCost.vb
@@ -53,7 +53,13 @@ Public Class TaskUpdateDesignForCost
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdateDrawingStylesFromTemplate.vb
+++ b/My Project/TaskUpdateDrawingStylesFromTemplate.vb
@@ -71,7 +71,13 @@ Public Class TaskUpdateDrawingStylesFromTemplate
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdateDrawingViews.vb
+++ b/My Project/TaskUpdateDrawingViews.vb
@@ -51,7 +51,13 @@ Public Class TaskUpdateDrawingViews
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdateMaterialFromMaterialTable.vb
+++ b/My Project/TaskUpdateMaterialFromMaterialTable.vb
@@ -64,7 +64,13 @@ Public Class TaskUpdateMaterialFromMaterialTable
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdateModelSizeInVariableTable.vb
+++ b/My Project/TaskUpdateModelSizeInVariableTable.vb
@@ -99,7 +99,13 @@ Public Class TaskUpdateModelSizeInVariableTable
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdateModelStylesFromTemplate.vb
+++ b/My Project/TaskUpdateModelStylesFromTemplate.vb
@@ -73,7 +73,13 @@ Public Class TaskUpdateModelStylesFromTemplate
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdatePartCopies.vb
+++ b/My Project/TaskUpdatePartCopies.vb
@@ -59,7 +59,13 @@ Public Class TaskUpdatePartCopies
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/TaskUpdatePhysicalProperties.vb
+++ b/My Project/TaskUpdatePhysicalProperties.vb
@@ -66,7 +66,13 @@ Public Class TaskUpdatePhysicalProperties
         Return ErrorMessage
 
     End Function
+    Public Overrides Function Process(ByVal FileName As String) As Dictionary(Of Integer, List(Of String))
 
+        Dim ErrorMessage As New Dictionary(Of Integer, List(Of String))
+
+        Return ErrorMessage
+
+    End Function
     Private Function ProcessInternal(
         ByVal SEDoc As SolidEdgeFramework.SolidEdgeDocument,
         ByVal Configuration As Dictionary(Of String, String),

--- a/My Project/Task_Common.vb
+++ b/My Project/Task_Common.vb
@@ -183,35 +183,37 @@ Public Class Task_Common
         ' If the type is not recognized, the empty string is returned.
         Dim DocType As String = ""
 
-        Select Case SEDoc.Type
+        If Not IsNothing(SEDoc) Then
+            Select Case SEDoc.Type
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igAssemblyDocument
-                DocType = "asm"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igAssemblyDocument
+                    DocType = "asm"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igWeldmentAssemblyDocument
-                DocType = "asm"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igWeldmentAssemblyDocument
+                    DocType = "asm"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igSyncAssemblyDocument
-                DocType = "asm"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igSyncAssemblyDocument
+                    DocType = "asm"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igPartDocument
-                DocType = "par"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igPartDocument
+                    DocType = "par"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igSyncPartDocument
-                DocType = "par"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igSyncPartDocument
+                    DocType = "par"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igSheetMetalDocument
-                DocType = "psm"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igSheetMetalDocument
+                    DocType = "psm"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igSyncSheetMetalDocument
-                DocType = "psm"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igSyncSheetMetalDocument
+                    DocType = "psm"
 
-            Case Is = SolidEdgeFramework.DocumentTypeConstants.igDraftDocument
-                DocType = "dft"
+                Case Is = SolidEdgeFramework.DocumentTypeConstants.igDraftDocument
+                    DocType = "dft"
 
-            Case Else
-                MsgBox(String.Format("{0} DocType '{1}' not recognized", "Task_Common", SEDoc.Type.ToString))
-        End Select
+                Case Else
+                    MsgBox(String.Format("{0} DocType '{1}' not recognized", "Task_Common", SEDoc.Type.ToString))
+            End Select
+        End If
 
         Return DocType
     End Function


### PR DESCRIPTION
Tasks have a new property "SolidEdgeRequired" by default set to true
Tasks that can be invoked without the need to open Solid Edge overrides the requirement by code or by user interface
Start check ensure that all the selected tasks are compatible with the SolidEdgeRequired property