### PR TITLE
Fixed a problem in creating custom property with MCDF

### DIFF
--- a/My Project/TaskEditProperties.vb
+++ b/My Project/TaskEditProperties.vb
@@ -480,7 +480,9 @@ Public Class TaskEditProperties
 
                                 Try
                                     Dim userProperties = co.UserDefinedProperties
-                                    Dim newPropertyId As UInteger = CType(userProperties.PropertyNames.Keys.Max() + 1, UInteger)
+                                    Dim newPropertyId As UInteger = 0
+
+                                    If userProperties.PropertyNames.Keys.Count > 0 Then newPropertyId = CType(userProperties.PropertyNames.Keys.Max() + 1, UInteger)
                                     'This is the ID the new property will have
                                     'Duplicated IDs are not allowed
                                     'We need a method to calculate an unique ID; .Max() seems a good one cause .Max() + 1 should be unique


### PR DESCRIPTION
The method Max() works only if the keys collection is populated, in case of 0 elements returns an exception.
https://github.com/rmcanany/SolidEdgeHousekeeper/issues/123#issuecomment-2338219468