### PR TITLE
Update placeholder text on icons. Add flat pattern status check to TaskCreateDrawingOfFlatPattern

### DIFF
--- a/My Project/Form_Main.Designer.vb
+++ b/My Project/Form_Main.Designer.vb
@@ -389,7 +389,7 @@ Partial Class Form_Main
         Me.new_ButtonFileSearchDelete.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.new_ButtonFileSearchDelete.Name = "new_ButtonFileSearchDelete"
         Me.new_ButtonFileSearchDelete.Size = New System.Drawing.Size(23, 22)
-        Me.new_ButtonFileSearchDelete.Text = "ToolStripButton5"
+        Me.new_ButtonFileSearchDelete.Text = "Clear"
         '
         'ToolStripSeparator7
         '
@@ -534,7 +534,7 @@ Partial Class Form_Main
         Me.new_CheckBoxFilterDft.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.new_CheckBoxFilterDft.Name = "new_CheckBoxFilterDft"
         Me.new_CheckBoxFilterDft.Size = New System.Drawing.Size(23, 22)
-        Me.new_CheckBoxFilterDft.Text = "ToolStripButton2"
+        Me.new_CheckBoxFilterDft.Text = "Filter DFT"
         '
         'new_CheckBoxFilterPsm
         '
@@ -547,7 +547,7 @@ Partial Class Form_Main
         Me.new_CheckBoxFilterPsm.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.new_CheckBoxFilterPsm.Name = "new_CheckBoxFilterPsm"
         Me.new_CheckBoxFilterPsm.Size = New System.Drawing.Size(23, 22)
-        Me.new_CheckBoxFilterPsm.Text = "ToolStripButton3"
+        Me.new_CheckBoxFilterPsm.Text = "Filter PSM"
         '
         'new_CheckBoxFilterPar
         '
@@ -561,7 +561,7 @@ Partial Class Form_Main
         Me.new_CheckBoxFilterPar.Name = "new_CheckBoxFilterPar"
         Me.new_CheckBoxFilterPar.RightToLeft = System.Windows.Forms.RightToLeft.No
         Me.new_CheckBoxFilterPar.Size = New System.Drawing.Size(23, 22)
-        Me.new_CheckBoxFilterPar.Text = "ToolStripButton1"
+        Me.new_CheckBoxFilterPar.Text = "Filter PAR"
         '
         'new_CheckBoxFilterAsm
         '
@@ -574,7 +574,7 @@ Partial Class Form_Main
         Me.new_CheckBoxFilterAsm.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.new_CheckBoxFilterAsm.Name = "new_CheckBoxFilterAsm"
         Me.new_CheckBoxFilterAsm.Size = New System.Drawing.Size(23, 22)
-        Me.new_CheckBoxFilterAsm.Text = "ToolStripButton4"
+        Me.new_CheckBoxFilterAsm.Text = "Filter ASM"
         '
         'ToolStripLabel1
         '

--- a/My Project/TaskCreateDrawingOfFlatPattern.vb
+++ b/My Project/TaskCreateDrawingOfFlatPattern.vb
@@ -314,6 +314,11 @@ Public Class TaskCreateDrawingOfFlatPattern
             ExitStatus = 1
             ErrorMessageList.Add("No flat patterns detected")
         End If
+        
+        If FlatPatternModels.Count > 0 AndAlso FlatPatternModels.Item(1).FlatPatterns.Item(1).Status = SolidEdgePart.FeatureStatusConstants.igFeatureFailed Then
+            ExitStatus = 1
+            ErrorMessageList.Add("Flat pattern feature is in a failed state")
+        End If
 
         If ExitStatus = 0 Then
             FlatPatternModel = FlatPatternModels.Item(1)


### PR DESCRIPTION
Updated the placeholder text on the ASM/PAR/PSM/DFT filter button, as well as the Clear button on the wildcard search box.

When a flat pattern feature is in a failed state, TaskCreateDrawingOfFlatPattern will throw an E_FAIL COMException when trying to generate the drawing from the flat pattern. This PR checks the first flat pattern on the first flat pattern model for the  igFeatureFailed status, sets the exist status, and gracefully logs the failure.