### PR TITLE
Added initial state-check to disable the property filter button and wildcard file match text box.

### DIFF
--- a/My Project/Form_Main.Designer.vb
+++ b/My Project/Form_Main.Designer.vb
@@ -361,6 +361,11 @@ Partial Class Form_Main
         Me.new_ButtonPropertyFilter.Name = "new_ButtonPropertyFilter"
         Me.new_ButtonPropertyFilter.Size = New System.Drawing.Size(23, 22)
         Me.new_ButtonPropertyFilter.Text = "Configure"
+        If Not CheckBoxEnablePropertyFilter.Checked Then
+            Me.new_ButtonPropertyFilter.Enabled = False
+        Else
+            Me.new_ButtonPropertyFilter.Enabled = True
+        End If
         '
         'ToolStripSeparator6
         '
@@ -381,6 +386,11 @@ Partial Class Form_Main
         Me.ComboBoxFileWildcard.Name = "ComboBoxFileWildcard"
         Me.ComboBoxFileWildcard.Size = New System.Drawing.Size(140, 25)
         Me.ComboBoxFileWildcard.Sorted = True
+        If Not CheckBoxEnableFileWildcard.Checked Then
+            Me.ComboBoxFileWildcard.Enabled = False
+        Else
+            Me.ComboBoxFileWildcard.Enabled = True
+        End If
         '
         'new_ButtonFileSearchDelete
         '


### PR DESCRIPTION
Enabled state of these elements was not being checked on load, hence they would not load in a disabled state if the check boxes were unchecked on initial load.

I've been brushing up on the basics of Winforms and WPF. I think I followed best practices here. It worked in my quick test. Please double-check that I didn't do anything stupid.

Sorry for nickel and diming these. I'd rather do one big PR at the end of the week but I don't know how the rest of my week is going to look so I want to get these out as I can.