### PR TITLE
Add property if not exists while editing from ListView

### DIFF
--- a/My Project/TaskEditProperties.vb
+++ b/My Project/TaskEditProperties.vb
@@ -507,7 +507,7 @@ Public Class TaskEditProperties
                                     'Alternatively we need a method that find unused IDs inbetwen existing one; this will find unused IDs from previous property deletion
 
                                     userProperties.PropertyNames(newPropertyId) = PropertyNameEnglish
-                                    OLEProp = userProperties.NewProperty(VTPropertyType.VT_LPWSTR, newPropertyId)
+                                    OLEProp = userProperties.NewProperty(VTPropertyType.VT_LPSTR, newPropertyId)
                                     OLEProp.Value = " "
                                     userProperties.AddProperty(OLEProp)
                                     Dim i = 0

--- a/My Project/UtilsCommon.vb
+++ b/My Project/UtilsCommon.vb
@@ -885,6 +885,31 @@ Public Class UtilsCommon
 
             OLEProp = co.UserDefinedProperties.Properties.FirstOrDefault(Function(Proper) Proper.PropertyName = PropertyNameEnglish)
 
+            If IsNothing(OLEProp) Then ' Add it
+
+                Try
+                    Dim userProperties = co.UserDefinedProperties
+                    Dim newPropertyId As UInteger = 2 'For some reason when custom property is empty there is an hidden property therefore the starting index must be 2
+
+                    If userProperties.PropertyNames.Keys.Count > 0 Then newPropertyId = CType(userProperties.PropertyNames.Keys.Max() + 1, UInteger)
+                    'This is the ID the new property will have
+                    'Duplicated IDs are not allowed
+                    'We need a method to calculate an unique ID; .Max() seems a good one cause .Max() + 1 should be unique
+                    'Alternatively we need a method that find unused IDs inbetwen existing one; this will find unused IDs from previous property deletion
+
+                    userProperties.PropertyNames(newPropertyId) = PropertyNameEnglish
+                    OLEProp = userProperties.NewProperty(VTPropertyType.VT_LPSTR, newPropertyId)
+                    OLEProp.Value = " "
+                    userProperties.AddProperty(OLEProp)
+                    Dim i = 0
+                Catch ex As Exception
+
+                    MsgBox("Could not change property", vbOKOnly)
+
+                End Try
+
+            End If
+
         End If
 
         OLEProp.Value = PropertyValue


### PR DESCRIPTION
There is an important change in code at https://github.com/rmcanany/SolidEdgeHousekeeper/commit/8a6320c205f31162e8532c22e8a087ce801f9d61#diff-51427d4169ea05360aee8ab1bf3624e257cc57e60c51f282132f35c6375f0431L510

The VTPropertyType must be VT_LPSTR instead of VT_LPWSTR; using the wrong one leads to the custom property not being visible in the standard Windows properties pane, it still works in Solid Edge but better to use the correct one.

I have updated the code, I think it's important to release a new version with this fix.