### PR TITLE
Update UtilsExecute to try default .log program first

### DIFF
--- a/My Project/UtilsExecute.vb
+++ b/My Project/UtilsExecute.vb
@@ -128,7 +128,13 @@ Public Class UtilsExecute
         FMain.ButtonCancel.Text = "Cancel"
 
         If Me.UtilsLogFile.ErrorsOccurred Then
-            Process.Start("Notepad.exe", Me.UtilsLogFile.MissingFilesFileName)
+            Try
+                ' Try to use the default application to open the file.
+                Process.Start(Me.UtilsLogFile.MissingFilesFileName)
+            Catch ex As Exception
+                ' If none, open with notepad.exe
+                Process.Start("notepad.exe", Me.UtilsLogFile.MissingFilesFileName)
+            End Try
         Else
             FMain.TextBoxStatus.Text = FMain.TextBoxStatus.Text + "  All checks passed."
         End If


### PR DESCRIPTION
This changes the default behavior of UtilsExecute opening "notepad.exe," and instead tries to use the default program set with Windows, if there is no default program, it should fall back to using notepad.exe.